### PR TITLE
Add configurable page size control to issues table

### DIFF
--- a/app/components/PageSizeSelect.tsx
+++ b/app/components/PageSizeSelect.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Select } from "@radix-ui/themes";
+import { useRouter, useSearchParams } from "next/navigation";
+
+interface Props {
+    pageSize: number;
+}
+
+const PageSizeSelect = ({ pageSize }: Props) => {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const sizes = [5, 10, 15, 20, 30, 50];
+
+    return (
+        <Select.Root
+            value={pageSize.toString()}
+            onValueChange={(value) => {
+                const params = new URLSearchParams(searchParams.toString());
+                if (value) {
+                    params.set("pageSize", value);
+                } else {
+                    params.delete("pageSize");
+                }
+                params.delete("page");
+                const query = params.toString();
+                router.push(`/issues${query ? `?${query}` : ""}`);
+            }}
+        >
+            <Select.Trigger placeholder="Page size..." />
+            <Select.Content>
+                <Select.Group>
+                    {sizes.map((size) => (
+                        <Select.Item key={size} value={size.toString()}>
+                            {size}
+                        </Select.Item>
+                    ))}
+                </Select.Group>
+            </Select.Content>
+        </Select.Root>
+    );
+};
+
+export default PageSizeSelect;

--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -16,7 +16,7 @@ const Pagination = ({itemsCount, currentPage, pageSize}: Props) => {
     const searchParams = useSearchParams();
 
     const changePage = (page: number) => {
-        const params = new URLSearchParams(searchParams);
+        const params = new URLSearchParams(searchParams.toString());
         params.set('page', page.toString());
         router.push('?' + params.toString())
     }

--- a/app/issues/IssueStatusFilter.tsx
+++ b/app/issues/IssueStatusFilter.tsx
@@ -17,13 +17,16 @@ const IssueStatusFilter = () => {
 
     return (
         <Select.Root onValueChange={(status) => {
-            const params = new URLSearchParams();
-            if (status) params.append('status', status);
-            if (searchParams.get('orderBy'))
-                params.append('orderBy', searchParams.get('orderBy')!);
+            const params = new URLSearchParams(searchParams.toString());
+            if (status && status.trim()) {
+                params.set('status', status as Status);
+            } else {
+                params.delete('status');
+            }
+            params.delete('page');
 
-            const query = params.size ? '?' + params.toString() : '';
-            router.push('/issues' + query);
+            const query = params.toString();
+            router.push(`/issues${query ? `?${query}` : ''}`);
         }}>
             <Select.Trigger placeholder="Filter by status..."/>
             <Select.Content>

--- a/app/issues/IssueTable.tsx
+++ b/app/issues/IssueTable.tsx
@@ -6,9 +6,10 @@ import {IssueStatusBadge, Link} from "@/app/components";
 import {Issue, Status} from ".prisma/client";
 
 export interface IssueQuery {
-    status: Status,
-    orderBy: keyof Issue,
-    page: string,
+    status?: Status;
+    orderBy?: keyof Issue;
+    page?: string;
+    pageSize?: string;
 }
 
 interface Props {


### PR DESCRIPTION
## Summary
- add a client page size selector component that updates the issues listing query parameters
- update the issues index page to respect the `pageSize` search param and show the selector beside pagination
- ensure pagination and status filter preserve existing query params when navigating

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daa0877ff08330b2a3b4c4100cb729