### PR TITLE
Add IDE metadata to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # misc
 .DS_Store
+.idea/
 *.pem
 
 # debug


### PR DESCRIPTION
## Summary
- add the JetBrains `.idea` directory to the gitignore so IDE metadata stays local

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68daa91c31508330be8a39c63f4c6b45